### PR TITLE
Added missing configuration of maven-license-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,13 @@
           <artifactId>maven-jetty-plugin</artifactId>
           <version>${maven-jetty-plugin.version}</version>
         </plugin>
+       <plugin>
+        <groupId>com.cloudbees</groupId>
+        <artifactId>maven-license-plugin</artifactId>
+        <version>${maven-license-plugin.version}</version>
+        </plugin>
       </plugins>
+
     </pluginManagement>
 
     <plugins>
@@ -464,5 +470,6 @@
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
     <versions-maven-plugin.version>1.2</versions-maven-plugin.version>
     <xml-maven-plugin.version>1.0-beta-3</xml-maven-plugin.version>
+    <maven-license-plugin.version>1.3</maven-license-plugin.version>
   </properties>
 </project>


### PR DESCRIPTION
When compiling my plug-ins maven reports a missing version of the license plug-in.
