### PR TITLE
Ban Maven 3.0 through 3.0.3, also fix prerequisites in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -557,6 +557,25 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
+                  <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.</message>
+                </requireMavenVersion>
+                <requireMavenVersion>
+                  <version>(,3.0),[3.0.4,)</version>
+                  <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release Plugin.</message>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>display-info</id>
             <phase>validate</phase>
             <goals>
               <goal>display-info</goal>
@@ -637,7 +656,7 @@
     <maven-pmd-plugin.version>2.5</maven-pmd-plugin.version>
     <maven-project-info-reports-plugin.version>2.4</maven-project-info-reports-plugin.version>
     <maven-reactor-plugin.version>1.0</maven-reactor-plugin.version>
-    <maven-release-plugin.version>2.2.1</maven-release-plugin.version>
+    <maven-release-plugin.version>2.2.2</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>1.2.1</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
     <maven-site-plugin.version>3.0</maven-site-plugin.version>


### PR DESCRIPTION
BTW, it is a really sucky plan to list every plugin in the world in the parent pom. A better plan is to list the lifecycle plugins and the one or two "important" non-lifecycle plugins, e.g. maven-release-plugin, the eclipse plugin (to give the lifecycle hints) and the reporting plugins (if we are using them for reporting)... IOW if a plugin is used in one/two projects then it should really be only defined in those projects

Here is the output from versions:display-plugin-updates...

[INFO] Scanning for projects...
[INFO]  
[INFO] ------------------------------------------------------------------------
[INFO] Building Jenkins 1.26-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:1.3.1:display-plugin-updates (default-cli) @ jenkins ---
[INFO] 
[INFO] The following plugin updates are available:
[INFO]   com.cloudbees:maven-license-plugin ....................... 1.3 -> 1.4
[INFO]   maven-assembly-plugin .................................. 2.2.1 -> 2.3
[INFO]   maven-checkstyle-plugin .................................. 2.6 -> 2.9
[INFO]   maven-dependency-plugin .................................. 2.3 -> 2.4
[INFO]   maven-deploy-plugin ...................................... 2.6 -> 2.7
[INFO]   maven-eclipse-plugin ..................................... 2.8 -> 2.9
[INFO]   maven-gpg-plugin ......................................... 1.3 -> 1.4
[INFO]   maven-idea-plugin ............................... 2.2 -> 2.3-20100704
[INFO]   maven-jar-plugin ....................................... 2.3.1 -> 2.4
[INFO]   maven-javadoc-plugin ................................... 2.8 -> 2.8.1
[INFO]   maven-pmd-plugin ......................................... 2.5 -> 2.7
[INFO]   maven-surefire-plugin ................................... 2.9 -> 2.12
[INFO]   maven-surefire-report-plugin ............................ 2.9 -> 2.12
[INFO]   maven-war-plugin ....................................... 2.1.1 -> 2.2
[INFO]   org.codehaus.cargo:cargo-maven2-plugin ............... 1.1.2 -> 1.2.0
[INFO]   org.codehaus.gmaven:gmaven-plugin ........................ 1.3 -> 1.4
[INFO]   org.codehaus.mojo:exec-maven-plugin .................... 1.2 -> 1.2.1
[INFO]   org.codehaus.mojo:findbugs-maven-plugin .............. 2.3.2 -> 2.4.0
[INFO]   org.codehaus.mojo:gwt-maven-plugin ................. 2.3.0-1 -> 2.4.0
[INFO]   org.jenkins-ci.tools:maven-hpi-plugin .................. 1.74 -> 1.79
[INFO]   org.mortbay.jetty:maven-jetty-plugin ........... 6.1.26 -> 7.0.0.pre5
[INFO] 
[INFO] All plugins have a version specified.
[INFO] 
[INFO] Project defines minimum Maven version as: 2.2.1
[INFO] Plugins require minimum Maven version of: 2.2.1
[INFO] 
[INFO] No plugins require a newer version of Maven than specified by the pom.
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.374s
[INFO] Finished at: Tue Feb 14 10:01:14 GMT 2012
[INFO] Final Memory: 12M/81M
[INFO] ------------------------------------------------------------------------

I will leave it to others to test these updates.

Note, I think as a minimum remove the maven-idea-plugin as that is completely deprecated for some time now.
