### PR TITLE
[INFRA-588] maven.j.o => repo.j.o

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -89,7 +89,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -103,11 +103,11 @@
     <repository>
       <uniqueVersion>false</uniqueVersion>
       <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases</url>
+      <url>https://repo.jenkins-ci.org/releases/</url>
     </repository>
     <snapshotRepository>
       <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/snapshots</url>
+      <url>https://repo.jenkins-ci.org/snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
URL have been changed quite a long time ago, and started to fail badly recently. Time to fix those.

Ping @rtyler 