### PR TITLE
[JENKINS-37565] Allow specifying custom java.level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -583,14 +583,16 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.${java.level}</source>
+          <target>1.${java.level}</target>
+          <testSource>1.${java.level.test}</testSource>
+          <testTarget>1.${java.level.test}</testTarget>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-idea-plugin</artifactId>
         <configuration>
-          <jdkName>JDK1.6</jdkName>
+          <jdkName>JDK1.${java.level}</jdkName>
         </configuration>
       </plugin>
       <plugin>
@@ -611,6 +613,12 @@
   <properties>
     <!-- By default only check remote repositories once per week -->
     <maven.repository.update.freqency>interval:10080</maven.repository.update.freqency>
+
+    <!-- Starting from Jenkins 1.625.x Jenkins supports Java 7 only, hence we may want to bump the dependency in components -->
+    <java.level>6</java.level>
+    <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
+    <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
+    <java.level.test>${java.level}</java.level.test>
 
     <!-- Define all plugin versions as properties so individual hierarchies can easily override -->
     <apt-maven-plugin.version>1.0-alpha-4</apt-maven-plugin.version>


### PR DESCRIPTION
It is required for [JENKINS-37565](https://issues.jenkins-ci.org/browse/JENKINS-37565)
I have not touched the default version just in case other components still need Java 6.

@reviewbybees @jenkinsci/code-reviewers 