### PR TITLE
[JENKINS-46603] Upgrade plugins (esp. for JDK9 compat)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
                         </sources>
                     </configuration>
                 </execution>
-          </executions>          
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
@@ -657,7 +657,7 @@
           </dependency>
         </dependencies>
       </plugin>
-      
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
@@ -677,7 +677,7 @@
           </signature>
         </configuration>
       </plugin>
-      
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
@@ -720,58 +720,58 @@
 
     <!-- Define all plugin versions as properties so individual hierarchies can easily override -->
     <animal-sniffer-plugin.version>1.16</animal-sniffer-plugin.version>
-    <apt-maven-plugin.version>1.0-alpha-4</apt-maven-plugin.version>
+    <apt-maven-plugin.version>1.0-alpha-5</apt-maven-plugin.version>
     <axistools-maven-plugin.version>1.4</axistools-maven-plugin.version>
-    <buildnumber-maven-plugin.version>1.0</buildnumber-maven-plugin.version>
-    <build-helper-maven-plugin.version>1.7</build-helper-maven-plugin.version>
+    <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <cargo-maven2-plugin.version>1.1.2</cargo-maven2-plugin.version>
-    <cobertura-maven-plugin.version>2.5.1</cobertura-maven-plugin.version>
-    <exec-maven-plugin.version>1.2</exec-maven-plugin.version>
-    <findbugs-maven-plugin.version>2.3.2</findbugs-maven-plugin.version>
+    <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
+    <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+    <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
     <gmaven-plugin.version>1.5-jenkins-3</gmaven-plugin.version>
     <gwt-maven-plugin.version>2.3.0-1</gwt-maven-plugin.version>
-    <javancss-maven-plugin.version>2.0</javancss-maven-plugin.version>
-    <jdepend-maven-plugin.version>2.0-beta-2</jdepend-maven-plugin.version>
+    <javancss-maven-plugin.version>2.1</javancss-maven-plugin.version>
+    <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
     <kohsuke-gmaven-plugin.version>1.0-rc-5-patch-2</kohsuke-gmaven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-antrun-extended-plugin.version>1.42</maven-antrun-extended-plugin.version>
     <maven-antrun-plugin.version>1.3</maven-antrun-plugin.version>
-    <maven-assembly-plugin.version>2.2.1</maven-assembly-plugin.version>
-    <maven-changelog-plugin.version>2.2</maven-changelog-plugin.version>
-    <maven-checkstyle-plugin.version>2.6</maven-checkstyle-plugin.version>
-    <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>2.5</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>2.3</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>2.6</maven-deploy-plugin.version>
-    <maven-doap-plugin.version>1.1</maven-doap-plugin.version>
-    <maven-eclipse-plugin.version>2.8</maven-eclipse-plugin.version>
+    <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
+    <maven-changelog-plugin.version>2.3</maven-changelog-plugin.version>
+    <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
+    <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
+    <maven-compiler-plugin.version>3.6.2</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.0.1</maven-dependency-plugin.version>
+    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <maven-doap-plugin.version>1.2</maven-doap-plugin.version>
+    <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
-    <maven-gpg-plugin.version>1.3</maven-gpg-plugin.version>
-    <maven-help-plugin.version>2.1.1</maven-help-plugin.version>
-    <maven-hpi-plugin.version>1.115</maven-hpi-plugin.version>
+    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <maven-help-plugin.version>2.2</maven-help-plugin.version>
+    <maven-hpi-plugin.version>2.0</maven-hpi-plugin.version>
     <maven-idea-plugin.version>2.2</maven-idea-plugin.version>
-    <maven-install-plugin.version>2.3.1</maven-install-plugin.version>
-    <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>2.3.1</maven-jar-plugin.version>
+    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+    <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
+    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>
-    <maven-jxr-plugin.version>2.3</maven-jxr-plugin.version>
-    <maven-localizer-plugin.version>1.14</maven-localizer-plugin.version>
-    <maven-pmd-plugin.version>2.5</maven-pmd-plugin.version>
-    <maven-project-info-reports-plugin.version>2.4</maven-project-info-reports-plugin.version>
-    <maven-reactor-plugin.version>1.0</maven-reactor-plugin.version>
-    <maven-release-plugin.version>2.5</maven-release-plugin.version>
-    <maven-remote-resources-plugin.version>1.2.1</maven-remote-resources-plugin.version>
-    <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
-    <maven-site-plugin.version>3.0</maven-site-plugin.version>
+    <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
+    <maven-localizer-plugin.version>1.24</maven-localizer-plugin.version>
+    <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
+    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+    <maven-reactor-plugin.version>1.1</maven-reactor-plugin.version>
+    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
+    <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
+    <maven-site-plugin.version>3.6</maven-site-plugin.version>
     <maven-sorcerer-plugin.version>0.8</maven-sorcerer-plugin.version>
-    <maven-source-plugin.version>2.1.2</maven-source-plugin.version>
+    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <maven-stapler-plugin.version>1.17</maven-stapler-plugin.version>
     <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>2.9</maven-surefire-report-plugin.version>
-    <maven-war-plugin.version>2.1.1</maven-war-plugin.version>
+    <maven-surefire-report-plugin.version>2.20</maven-surefire-report-plugin.version>
+    <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
-    <versions-maven-plugin.version>1.3.1</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.4</versions-maven-plugin.version>
     <xml-maven-plugin.version>1.0</xml-maven-plugin.version>
     <maven-license-plugin.version>1.7</maven-license-plugin.version>
   </properties>


### PR DESCRIPTION
Filed downstream https://github.com/jenkinsci/jenkins/pull/2998 to verify this change does not break something.

```
$ mvn versions:display-plugin-updates
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Jenkins 1.39-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- versions-maven-plugin:1.3.1:display-plugin-updates (default-cli) @ jenkins ---
[INFO] artifact com.cloudbees:maven-license-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-assembly-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-changelog-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-checkstyle-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-clean-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-compiler-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-dependency-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-deploy-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-doap-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-eclipse-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-enforcer-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-gpg-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-help-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-idea-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-install-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-jar-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-javadoc-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-jxr-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-pmd-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-project-info-reports-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-reactor-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-release-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-remote-resources-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-resources-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-site-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-source-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-surefire-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-surefire-report-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.apache.maven.plugins:maven-war-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.cargo:cargo-maven2-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.gmaven:gmaven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:animal-sniffer-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:apt-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:axistools-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:buildnumber-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:exec-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:gwt-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:javancss-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:jdepend-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:openjpa-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:taglist-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:versions-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.codehaus.mojo:xml-maven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.jvnet.maven-antrun-extended-plugin:maven-antrun-extended-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.jvnet.sorcerer:maven-sorcerer-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.kohsuke.gmaven:gmaven-plugin: checking for updates from cloudbees-internal
[INFO] artifact org.mortbay.jetty:maven-jetty-plugin: checking for updates from cloudbees-internal
[INFO]
[INFO] The following plugin updates are available:
[INFO]   maven-assembly-plugin .................................. 2.2.1 -> 2.6
[INFO]   maven-changelog-plugin ................................... 2.2 -> 2.3
[INFO]   maven-checkstyle-plugin ................................. 2.6 -> 2.16
[INFO]   maven-clean-plugin ................................... 2.4.1 -> 2.6.1
[INFO]   maven-compiler-plugin .................................... 2.5 -> 3.3
[INFO]   maven-dependency-plugin ................................. 2.3 -> 2.10
[INFO]   maven-deploy-plugin .................................... 2.6 -> 2.8.2
[INFO]   maven-doap-plugin ........................................ 1.1 -> 1.2
[INFO]   maven-eclipse-plugin .................................... 2.8 -> 2.10
[INFO]   maven-gpg-plugin ......................................... 1.3 -> 1.6
[INFO]   maven-help-plugin ...................................... 2.1.1 -> 2.2
[INFO]   maven-idea-plugin ........................... 2.2 -> 2.3-atlassian-10
[INFO]   maven-install-plugin ................................. 2.3.1 -> 2.5.2
[INFO]   maven-jar-plugin ....................................... 2.3.1 -> 2.6
[INFO]   maven-jxr-plugin ......................................... 2.3 -> 2.5
[INFO]   maven-pmd-plugin ......................................... 2.5 -> 3.5
[INFO]   maven-project-info-reports-plugin ...................... 2.4 -> 2.8.1
[INFO]   maven-reactor-plugin ..................................... 1.0 -> 1.1
[INFO]   maven-release-plugin ................................... 2.5 -> 2.5.2
[INFO]   maven-remote-resources-plugin .......................... 1.2.1 -> 1.5
[INFO]   maven-resources-plugin ................................... 2.5 -> 2.7
[INFO]   maven-site-plugin ........................................ 3.0 -> 3.4
[INFO]   maven-source-plugin .................................... 2.1.2 -> 2.4
[INFO]   maven-surefire-report-plugin ............................ 2.9 -> 2.20
[INFO]   maven-war-plugin ....................................... 2.1.1 -> 2.6
[INFO]   org.codehaus.cargo:cargo-maven2-plugin ............... 1.1.2 -> 1.5.1
[INFO]   org.codehaus.mojo:apt-maven-plugin ....... 1.0-alpha-4 -> 1.0-alpha-5
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ............ 1.7 -> 1.9.1
[INFO]   org.codehaus.mojo:buildnumber-maven-plugin ............... 1.0 -> 1.3
[INFO]   org.codehaus.mojo:cobertura-maven-plugin ............... 2.5.1 -> 2.7
[INFO]   org.codehaus.mojo:exec-maven-plugin .................... 1.2 -> 1.4.0
[INFO]   org.codehaus.mojo:findbugs-maven-plugin .............. 2.3.2 -> 2.5.5
[INFO]   org.codehaus.mojo:gwt-maven-plugin ................. 2.3.0-1 -> 2.6.1
[INFO]   org.codehaus.mojo:javancss-maven-plugin .................. 2.0 -> 2.1
[INFO]   org.codehaus.mojo:jdepend-maven-plugin ............ 2.0-beta-2 -> 2.0
[INFO]   org.codehaus.mojo:versions-maven-plugin ................ 1.3.1 -> 2.2
[INFO]   org.jenkins-ci.tools:maven-hpi-plugin .................. 1.115 -> 2.0
[INFO]   org.jvnet.localizer:maven-localizer-plugin ............. 1.14 -> 1.24
[INFO]   org.jvnet.maven-antrun-extended-plugin:maven-antrun-extended-plugin  1.42 -> 1.43
[INFO]   org.mortbay.jetty:maven-jetty-plugin ........... 6.1.26 -> 7.0.0.pre5
[INFO]
[INFO] All plugins have a version specified.
[INFO]
[INFO] Project defines minimum Maven version as: 2.2.1
[INFO] Plugins require minimum Maven version of: 3.0
[INFO]
[ERROR] Project requires an incorrect minimum version of Maven.
[ERROR] Either change plugin versions to those compatible with 2.2.1
[ERROR] or update the pom.xml to contain
[ERROR]     <prerequisites>
[ERROR]       <maven>3.0</maven>
[ERROR]     </prerequisites>
[INFO]
[INFO] Require Maven 3.0 to use the following plugin updates:
[INFO]   maven-assembly-plugin ......................................... 3.1.0
[INFO]   maven-checkstyle-plugin ........................................ 2.17
[INFO]   maven-clean-plugin ............................................ 3.0.0
[INFO]   maven-compiler-plugin ......................................... 3.6.2
[INFO]   maven-dependency-plugin ....................................... 3.0.1
[INFO]   maven-enforcer-plugin ...................................... 3.0.0-M1
[INFO]   maven-jar-plugin .............................................. 3.0.2
[INFO]   maven-javadoc-plugin ....................................... 3.0.0-M1
[INFO]   maven-pmd-plugin ................................................ 3.8
[INFO]   maven-project-info-reports-plugin ............................... 2.9
[INFO]   maven-release-plugin .......................................... 2.5.3
[INFO]   maven-resources-plugin ........................................ 3.0.2
[INFO]   maven-site-plugin ............................................... 3.6
[INFO]   maven-source-plugin ........................................... 3.0.1
[INFO]   maven-war-plugin .............................................. 3.1.0
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ................... 3.0.0
[INFO]   org.codehaus.mojo:buildnumber-maven-plugin ...................... 1.4
[INFO]   org.codehaus.mojo:exec-maven-plugin ........................... 1.6.0
[INFO]   org.codehaus.mojo:gwt-maven-plugin ............................ 2.8.1
[INFO]   org.codehaus.mojo:versions-maven-plugin ......................... 2.4
[INFO]   org.codehaus.mojo:xml-maven-plugin ............................ 1.0.1
[INFO]
[INFO] Require Maven 3.0.1 to use the following plugin updates:
[INFO]   org.codehaus.mojo:findbugs-maven-plugin ....................... 3.0.5
[INFO]
[INFO] Require Maven 3.2.2 to use the following plugin updates:
[INFO]   org.codehaus.cargo:cargo-maven2-plugin ........................ 1.6.4
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:49 min
[INFO] Finished at: 2017-09-02T01:12:21+02:00
[INFO] Final Memory: 21M/372M
[INFO] ------------------------------------------------------------------------

```

@reviewbybees 