### PR TITLE
Bump to extra-enforcer-rules 1.0-beta-7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -653,7 +653,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-beta-6</version>
+            <version>1.0-beta-7</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
The version was just released with a few fixes, including two from @jglick and @Vlatombe which improves corruption detection and hints about the problematic files. So we should propagate that usage.

https://github.com/mojohaus/extra-enforcer-rules/milestone/5?closed=1

@reviewbybees