### PR TITLE
[JENKINS-51247] Always use source:jar-no-fork, not source:jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -733,6 +733,34 @@
         <maven.repository.update.freqency>always</maven.repository.update.freqency>
       </properties>
     </profile>
+    <profile> <!-- JENKINS-51247: bypass MNG-6405 by avoiding use of forked executions incl. from source:jar -->
+      <id>fix-superpom-source-fork</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>DO-NOT-ACTUALLY-RUN</phase>
+              </execution>
+              <execution>
+                <id>attach-sources-no-fork</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile> <!-- see JEP-305 -->
       <id>consume-incrementals</id>
       <repositories>


### PR DESCRIPTION
Trying to fix the problem that necessitated an emergency workaround in https://github.com/jenkinsci/jenkins/pull/3441.