### PR TITLE
[JENKINS-51247] Superpom as of MNG-5940 in Maven 3.5.4 obsoletes the need for a MNG-6405 workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -733,34 +733,6 @@
         <maven.repository.update.freqency>always</maven.repository.update.freqency>
       </properties>
     </profile>
-    <profile> <!-- JENKINS-51247: bypass MNG-6405 by avoiding use of forked executions incl. from source:jar -->
-      <id>fix-superpom-source-fork</id>
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <phase>DO-NOT-ACTUALLY-RUN</phase>
-              </execution>
-              <execution>
-                <id>attach-sources-no-fork</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile> <!-- see JEP-305 -->
       <id>consume-incrementals</id>
       <repositories>
@@ -835,8 +807,8 @@
                 <configuration>
                   <rules>
                     <requireMavenVersion>
-                      <version>[3.5.0,)</version>
-                      <message>3.5.0+ required to use Incrementals.</message>
+                      <version>[3.5.4,)</version>
+                      <message>3.5.4+ required to use Incrementals.</message>
                     </requireMavenVersion>
                   </rules>
                 </configuration>


### PR DESCRIPTION
See comment in [MNG-6405](https://issues.apache.org/jira/browse/MNG-6405). Cleans up from #25 if we assume people are using the latest Maven release with https://github.com/apache/maven/pull/168. Not proposing immediate merge since I am not sure when CI systems will be updated, and currently we are not properly containerizing our builds.