### PR TITLE
Move incrementals-maven-plugin configuration out of a profile, so the default plugin prefix is available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,8 +590,20 @@
         <artifactId>maven-license-plugin</artifactId>
         <version>${maven-license-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>io.jenkins.tools.incrementals</groupId>
+          <artifactId>incrementals-maven-plugin</artifactId>
+          <version>${incrementals-plugin.version}</version>
+          <configuration>
+            <includes>
+              <include>org.jenkins-ci.*</include>
+              <include>io.jenkins.*</include>
+            </includes>
+            <generateBackupPoms>false</generateBackupPoms>
+            <updateNonincremental>false</updateNonincremental>
+          </configuration>
+        </plugin>
       </plugins>
-
     </pluginManagement>
 
     <plugins>
@@ -753,25 +765,6 @@
           </snapshots>
         </pluginRepository>
       </pluginRepositories>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>io.jenkins.tools.incrementals</groupId>
-              <artifactId>incrementals-maven-plugin</artifactId>
-              <version>${incrementals-plugin.version}</version>
-              <configuration>
-                <includes>
-                  <include>org.jenkins-ci.*</include>
-                  <include>io.jenkins.*</include>
-                </includes>
-                <generateBackupPoms>false</generateBackupPoms>
-                <updateNonincremental>false</updateNonincremental>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
     </profile>
     <profile>
       <id>might-produce-incrementals</id>


### PR DESCRIPTION
I suspect #27 does not work as is:

    mvn incrementals:reincrementalify

does not work without this patch. You have to specify

    mvn io.jenkins.tools.incrementals:incrementals-maven-plugin:reincrementalify

`plugin-pom` already had this configuration block at top level so that

    mvn incrementals:incrementalify

would work OOTB on a new plugin. That is less of a concern for this POM, which is expected to be used for Incrementals only in a handful of cases, but also potentially applicable.