### PR TITLE
Update to extra-enforcer-rules with JDK 11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -696,7 +696,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-beta-7</version>
+            <version>1.1</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
cc @jenkinsci/java11-support 

Full diff of the updated dependency: https://github.com/mojohaus/extra-enforcer-rules/compare/extra-enforcer-rules-1.0-beta-7...extra-enforcer-rules-1.1

* [ ] TODO test with the core using a PR and a timestamped SNAPSHOT: see https://github.com/jenkinsci/jenkins/pull/3784