### PR TITLE
Update plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -942,7 +942,7 @@
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
     <maven-reactor-plugin.version>1.1</maven-reactor-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-    <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
+    <maven-remote-resources-plugin.version>1.6.0</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
     <maven-site-plugin.version>3.7</maven-site-plugin.version>
     <maven-sorcerer-plugin.version>0.8</maven-sorcerer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -936,7 +936,7 @@
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
     <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>
-    <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
+    <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
     <maven-localizer-plugin.version>1.24</maven-localizer-plugin.version>
     <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -930,7 +930,7 @@
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-help-plugin.version>3.1.0</maven-help-plugin.version>
-    <maven-hpi-plugin.version>2.3</maven-hpi-plugin.version>
+    <maven-hpi-plugin.version>2.7</maven-hpi-plugin.version>
     <maven-idea-plugin.version>2.2</maven-idea-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -943,7 +943,7 @@
     <maven-reactor-plugin.version>1.1</maven-reactor-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>1.6.0</maven-remote-resources-plugin.version>
-    <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
+    <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
     <maven-site-plugin.version>3.7</maven-site-plugin.version>
     <maven-sorcerer-plugin.version>0.8</maven-sorcerer-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -911,7 +911,7 @@
     <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <gmaven-plugin.version>1.5-jenkins-3</gmaven-plugin.version>
-    <gwt-maven-plugin.version>2.3.0-1</gwt-maven-plugin.version>
+    <gwt-maven-plugin.version>2.8.2</gwt-maven-plugin.version>
     <javancss-maven-plugin.version>2.1</javancss-maven-plugin.version>
     <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
     <kohsuke-gmaven-plugin.version>1.0-rc-5-patch-2</kohsuke-gmaven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -929,7 +929,7 @@
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-    <maven-help-plugin.version>3.0.1</maven-help-plugin.version>
+    <maven-help-plugin.version>3.1.0</maven-help-plugin.version>
     <maven-hpi-plugin.version>2.3</maven-hpi-plugin.version>
     <maven-idea-plugin.version>2.2</maven-idea-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -948,8 +948,8 @@
     <maven-sorcerer-plugin.version>0.8</maven-sorcerer-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <maven-stapler-plugin.version>1.17</maven-stapler-plugin.version>
-    <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>2.20</maven-surefire-report-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
+    <maven-surefire-report-plugin.version>3.0.0-M1</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -954,7 +954,7 @@
     <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
     <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
-    <xml-maven-plugin.version>1.0</xml-maven-plugin.version>
+    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
     <maven-license-plugin.version>1.7</maven-license-plugin.version>
     <incrementals-plugin.version>1.0-beta-5</incrementals-plugin.version>
     <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>

--- a/pom.xml
+++ b/pom.xml
@@ -924,7 +924,7 @@
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-doap-plugin.version>1.2</maven-doap-plugin.version>
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -924,7 +924,7 @@
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-doap-plugin.version>1.2</maven-doap-plugin.version>
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -916,7 +916,7 @@
     <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
     <kohsuke-gmaven-plugin.version>1.0-rc-5-patch-2</kohsuke-gmaven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-    <maven-antrun-extended-plugin.version>1.42</maven-antrun-extended-plugin.version>
+    <maven-antrun-extended-plugin.version>1.43</maven-antrun-extended-plugin.version>
     <maven-antrun-plugin.version>1.3</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-changelog-plugin.version>2.3</maven-changelog-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -939,7 +939,7 @@
     <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
     <maven-localizer-plugin.version>1.24</maven-localizer-plugin.version>
     <maven-pmd-plugin.version>3.11.0</maven-pmd-plugin.version>
-    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+    <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
     <maven-reactor-plugin.version>1.1</maven-reactor-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -920,7 +920,7 @@
     <maven-antrun-plugin.version>1.3</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-changelog-plugin.version>2.3</maven-changelog-plugin.version>
-    <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -907,7 +907,7 @@
     <axistools-maven-plugin.version>1.4</axistools-maven-plugin.version>
     <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
-    <cargo-maven2-plugin.version>1.1.2</cargo-maven2-plugin.version>
+    <cargo-maven2-plugin.version>1.7.0</cargo-maven2-plugin.version>
     <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <gmaven-plugin.version>1.5-jenkins-3</gmaven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -921,7 +921,7 @@
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-changelog-plugin.version>2.3</maven-changelog-plugin.version>
     <maven-checkstyle-plugin.version>3.0</maven-checkstyle-plugin.version>
-    <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
+    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -934,7 +934,7 @@
     <maven-idea-plugin.version>2.2</maven-idea-plugin.version>
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
     <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>
     <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
     <maven-localizer-plugin.version>1.24</maven-localizer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -927,7 +927,7 @@
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-doap-plugin.version>1.2</maven-doap-plugin.version>
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-help-plugin.version>3.0.1</maven-help-plugin.version>
     <maven-hpi-plugin.version>2.3</maven-hpi-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -948,8 +948,8 @@
     <maven-sorcerer-plugin.version>0.8</maven-sorcerer-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <maven-stapler-plugin.version>1.17</maven-stapler-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>3.0.0-M1</maven-surefire-report-plugin.version>
+    <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
+    <maven-surefire-report-plugin.version>2.20</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
     <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -950,7 +950,7 @@
     <maven-stapler-plugin.version>1.17</maven-stapler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>3.0.0-M1</maven-surefire-report-plugin.version>
-    <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
+    <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
     <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
     <versions-maven-plugin.version>2.5</versions-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -944,7 +944,7 @@
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>1.6.0</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-    <maven-site-plugin.version>3.7</maven-site-plugin.version>
+    <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     <maven-sorcerer-plugin.version>0.8</maven-sorcerer-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <maven-stapler-plugin.version>1.17</maven-stapler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,7 @@
     <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
     <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
-    <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
     <xml-maven-plugin.version>1.0</xml-maven-plugin.version>
     <maven-license-plugin.version>1.7</maven-license-plugin.version>
     <incrementals-plugin.version>1.0-beta-5</incrementals-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -938,7 +938,7 @@
     <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>
     <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
     <maven-localizer-plugin.version>1.24</maven-localizer-plugin.version>
-    <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
+    <maven-pmd-plugin.version>3.11.0</maven-pmd-plugin.version>
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <maven-reactor-plugin.version>1.1</maven-reactor-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -923,7 +923,7 @@
     <maven-checkstyle-plugin.version>3.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-doap-plugin.version>1.2</maven-doap-plugin.version>
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -932,7 +932,7 @@
     <maven-help-plugin.version>3.1.0</maven-help-plugin.version>
     <maven-hpi-plugin.version>2.7</maven-hpi-plugin.version>
     <maven-idea-plugin.version>2.2</maven-idea-plugin.version>
-    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>


### PR DESCRIPTION
Just made a pass of `versions:display-plugins-updates`. 

## Successful downstream PR builds with timestamped SNAPSHOT on the following components (`1.51-20181206.212314-4`):
* [x] Jenkins Core https://github.com/jenkinsci/jenkins/pull/3785 (PR failed, but on unrelated tests only)
* [x] Remoting https://github.com/jenkinsci/remoting/pull/310
* [x] Winstone https://github.com/jenkinsci/winstone/pull/59
* [x] Plugin Compat Tester https://github.com/jenkinsci/plugin-compat-tester/pull/91

Output was:

```
INFO] The following plugin updates are available:
[INFO]   io.jenkins.tools.incrementals:incrementals-maven-plugin  1.0-beta-5 -> 1.0-beta-7
[INFO]   maven-checkstyle-plugin ............................... 2.17 -> 3.0.0
[INFO]   maven-clean-plugin ................................... 3.0.0 -> 3.1.0
[INFO]   maven-dependency-plugin .............................. 3.0.2 -> 3.1.1
[INFO]   maven-deploy-plugin ............................... 2.8.2 -> 3.0.0-M1
[INFO]   maven-enforcer-plugin .......................... 3.0.0-M1 -> 3.0.0-M2
[INFO]   maven-help-plugin .................................... 3.0.1 -> 3.1.0
[INFO]   maven-idea-plugin ........................... 2.2 -> 2.3-atlassian-10
[INFO]   maven-install-plugin .............................. 2.5.2 -> 3.0.0-M1
[INFO]   maven-jar-plugin ..................................... 3.0.2 -> 3.1.0
[INFO]   maven-jxr-plugin ....................................... 2.5 -> 3.0.0
[INFO]   maven-pmd-plugin ...................................... 3.8 -> 3.11.0
[INFO]   maven-project-info-reports-plugin ...................... 2.9 -> 3.0.0
[INFO]   maven-remote-resources-plugin .......................... 1.5 -> 1.6.0
[INFO]   maven-resources-plugin ............................... 3.0.2 -> 3.1.0
[INFO]   maven-site-plugin ...................................... 3.7 -> 3.7.1
[INFO]   maven-surefire-plugin .............................. 2.20 -> 3.0.0-M1
[INFO]   maven-surefire-report-plugin ....................... 2.20 -> 3.0.0-M1
[INFO]   maven-war-plugin ..................................... 3.1.0 -> 3.2.2
[INFO]   org.codehaus.cargo:cargo-maven2-plugin ............... 1.1.2 -> 1.7.0
[INFO]   org.codehaus.mojo:gwt-maven-plugin ................. 2.3.0-1 -> 2.8.2
[INFO]   org.codehaus.mojo:versions-maven-plugin .................. 2.5 -> 2.7
[INFO]   org.codehaus.mojo:xml-maven-plugin ..................... 1.0 -> 1.0.2
[INFO]   org.jenkins-ci.tools:maven-hpi-plugin .................... 2.3 -> 2.7
[INFO]   org.jvnet.maven-antrun-extended-plugin:maven-antrun-extended-plugin  1.42 -> 1.43
[INFO]   org.mortbay.jetty:maven-jetty-plugin ........... 6.1.26 -> 7.0.0.pre5
```