### PR TITLE
Set source level for maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,9 @@
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
+          <configuration>
+            <source>${java.level}</source>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-jxr-plugin</artifactId>


### PR DESCRIPTION
Analogue of https://github.com/jenkinsci/plugin-pom/pull/196.

Was unable to verify that this allows the `jdk11` profile to be deleted from `jenkinsci/jenkins/pom.xml`, since I could not compile Jenkins core at all under Java 11 (error in `CrontabParser`). I did at least confirm that it causes `-source 8` to appear in `core/target/apidocs/options` as expected when using `-Ddebug`.