### PR TITLE
Printing static code analysis errors in log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -636,7 +636,52 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>se.bjurr.violations</groupId>
+        <artifactId>violations-maven-plugin</artifactId>
+        <version>${violations.version}</version>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>violations</goal>
+            </goals>
+            <configuration>
+              <minSeverity>INFO</minSeverity>
+              <detailLevel>VERBOSE</detailLevel>
+              <maxViolations>${violations.maxViolations}</maxViolations>
+              <printViolations>true</printViolations>
+              <diffPrintViolations>false</diffPrintViolations>
+              <violations>
+                <violation>
+                  <parser>FINDBUGS</parser>
+                  <reporter>Spotbugs</reporter>
+                  <folder>.</folder>
+                  <pattern>.*/spotbugsXml\.xml$</pattern>
+                </violation>
+                <violation>
+                  <parser>PMD</parser>
+                  <reporter>Pmd</reporter>
+                  <folder>.</folder>
+                  <pattern>.*/pmd\.xml$</pattern>
+                </violation>
+                <violation>
+                  <parser>CPD</parser>
+                  <reporter>CPD</reporter>
+                  <folder>.</folder>
+                  <pattern>.*/cpd\.xml$</pattern>
+                </violation>
+                <violation>
+                  <parser>CHECKSTYLE</parser>
+                  <reporter>Checkstyle</reporter>
+                  <folder>.</folder>
+                  <pattern>.*/checkstyle-result\.xml$</pattern>
+                </violation>
+              </violations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
@@ -906,6 +951,11 @@
     <!-- Defines an optional SpotBugs excludes file.
          Generally it is recommended to use @SuppressFBWarnings annotation unless you want to ignore an entire class of issues -->
     <spotbugs.excludeFilterFile>${findbugs.excludeFilterFile}</spotbugs.excludeFilterFile>
+
+    <!-- Maximum allowed number of violations found with static code analysis, or else fail the build. -->
+    <!-- You can set the spotbugs.failOnError to false and set violations.maxViolations to 0 to get a more verbose error in the build log. -->
+    <violations.maxViolations>999999</violations.maxViolations>
+    <violations.version>1.26</violations.version>
 
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>

--- a/pom.xml
+++ b/pom.xml
@@ -955,7 +955,7 @@
     <!-- Maximum allowed number of violations found with static code analysis, or else fail the build. -->
     <!-- You can set the spotbugs.failOnError to false and set violations.maxViolations to 0 to get a more verbose error in the build log. -->
     <violations.maxViolations>999999</violations.maxViolations>
-    <violations.version>1.26</violations.version>
+    <violations.version>1.28</violations.version>
 
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>


### PR DESCRIPTION
The build log may look like:

```bash
[INFO] 
[INFO] --- violations-maven-plugin:1.24:violations (default) @ generic-webhook-trigger ---
[INFO] No references specified, will not report violations in diff
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  55.612 s
[INFO] Finished at: 2019-10-05T10:38:50+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal se.bjurr.violations:violations-maven-plugin:1.24:violations (default) on project generic-webhook-trigger: Too many violations found, max is 0 but found 2
[ERROR] org/jenkinsci/plugins/gwt/GenericTrigger.java
[ERROR] |          |          |          |      |                                   |
[ERROR] | Reporter | Rule     | Severity | Line | Message                           |
[ERROR] |          |          |          |      |                                   |
[ERROR] +----------+----------+----------+------+-----------------------------------+
[ERROR] |          |          |          |      |                                   |
[ERROR] | Spotbugs | RV_RETUR | INFO     | 144  | Return value  of  method  without |
[ERROR] |          | N_VALUE_ |          |      | side effect  is  ignored  <p>This |
[ERROR] |          | IGNORED_ |          |      | code calls a method  and  ignores |
[ERROR] |          | NO_SIDE_ |          |      | the  return  value.  However  our |
[ERROR] |          | EFFECT   |          |      | analysis shows  that  the  method |
[ERROR] |          |          |          |      | (including its implementations in |
[ERROR] |          |          |          |      | subclasses  if  any)   does   not |
[ERROR] |          |          |          |      | produce  any  effect  other  than |
[ERROR] |          |          |          |      | return value. Thus this call  can |
[ERROR] |          |          |          |      | be removed. </p> <p>We are trying |
[ERROR] |          |          |          |      | to reduce the false positives  as |
[ERROR] |          |          |          |      | much as  possible,  but  in  some |
[ERROR] |          |          |          |      | cases  this  warning   might   be |
[ERROR] |          |          |          |      | wrong.   Common    false-positive |
[ERROR] |          |          |          |      | cases   include:</p>   <p>-   The |
[ERROR] |          |          |          |      | method   is   designed   to    be |
[ERROR] |          |          |          |      | overridden  and  produce  a  side |
[ERROR] |          |          |          |      | effect in  other  projects  which |
[ERROR] |          |          |          |      | are  out  of  the  scope  of  the |
[ERROR] |          |          |          |      | analysis.</p> <p>- The method  is |
[ERROR] |          |          |          |      | called  to  trigger   the   class |
[ERROR] |          |          |          |      | loading which  may  have  a  side |
[ERROR] |          |          |          |      | effect.</p> <p>-  The  method  is |
[ERROR] |          |          |          |      | called   just   to    get    some |
[ERROR] |          |          |          |      | exception.</p>  <p>If  you   feel |
[ERROR] |          |          |          |      | that our assumption is incorrect, |
[ERROR] |          |          |          |      | you can use  a  @CheckReturnValue |
[ERROR] |          |          |          |      | annotation to  instruct  FindBugs |
[ERROR] |          |          |          |      | that ignoring the return value of |
[ERROR] |          |          |          |      | this method is acceptable. </p>   |
[ERROR] |          |          |          |      |                                   |
[ERROR] +----------+----------+----------+------+-----------------------------------+
[ERROR] |          |          |          |      |                                   |
[ERROR] | Spotbugs | NP_NULL_ | ERROR    | 140  | Possible null pointer dereference |
[ERROR] |          | ON_SOME_ |          |      | <p>  There   is   a   branch   of |
[ERROR] |          | PATH     |          |      | statement      that,       <em>if |
[ERROR] |          |          |          |      | executed,</em> guarantees that  a |
[ERROR] |          |          |          |      | null value will be  dereferenced, |
[ERROR] |          |          |          |      | which    would     generate     a |
[ERROR] |          |          |          |      | <code>NullPointerException</code> |
[ERROR] |          |          |          |      | when the  code  is  executed.  Of |
[ERROR] |          |          |          |      | course, the problem might be that |
[ERROR] |          |          |          |      | the  branch   or   statement   is |
[ERROR] |          |          |          |      | infeasible  and  that  the   null |
[ERROR] |          |          |          |      | pointer exception can't  ever  be |
[ERROR] |          |          |          |      | executed; deciding that is beyond |
[ERROR] |          |          |          |      | the ability of FindBugs. </p>     |
[ERROR] |          |          |          |      |                                   |
[ERROR] +----------+----------+----------+------+-----------------------------------+
[ERROR] Summary of org/jenkinsci/plugins/gwt/GenericTrigger.java
[ERROR] |          |      |      |       |       |
[ERROR] | Reporter | INFO | WARN | ERROR | Total |
[ERROR] |          |      |      |       |       |
[ERROR] +----------+------+------+-------+-------+
[ERROR] |          |      |      |       |       |
[ERROR] | Spotbugs | 1    | 0    | 1     | 2     |
[ERROR] |          |      |      |       |       |
[ERROR] +----------+------+------+-------+-------+
[ERROR] |          |      |      |       |       |
[ERROR] |          | 1    | 0    | 1     | 2     |
[ERROR] |          |      |      |       |       |
[ERROR] +----------+------+------+-------+-------+
[ERROR] 
[ERROR] 
[ERROR] Summary
[ERROR] |          |      |      |       |       |
[ERROR] | Reporter | INFO | WARN | ERROR | Total |
[ERROR] |          |      |      |       |       |
[ERROR] +----------+------+------+-------+-------+
[ERROR] |          |      |      |       |       |
[ERROR] | Spotbugs | 1    | 0    | 1     | 2     |
[ERROR] |          |      |      |       |       |
[ERROR] +----------+------+------+-------+-------+
[ERROR] |          |      |      |       |       |
[ERROR] |          | 1    | 0    | 1     | 2     |
[ERROR] |          |      |      |       |       |
[ERROR] +----------+------+------+-------+-------+
```