### PR TITLE
Update test-annotations from 1.2 to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>test-annotations</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Bumps `test-annotations` from 1.2 to 1.3.

CC: @jenkinsci/hacktoberfest