### PR TITLE
Add Dependabot configuration file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+- package_manager: "java:maven"
+  directory: "/"
+  update_schedule: "weekly"
+
+  default_reviewers:
+    - "oleg-nenashev"


### PR DESCRIPTION
Inspired by [#44 (comment)](https://github.com/jenkinsci/pom/pull/44#pullrequestreview-300811649). I'm not the maintainer of this repository, so I don't think it's proper for me to file the Jira ticket to enable Dependabot. But I can at least assist in supplying a Dependabot configuration file.

CC: @jenkinsci/hacktoberfest