### PR TITLE
Add findsecbugs plugin to spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,13 @@
           <threshold>${spotbugs.threshold}</threshold>
           <!-- Empty by default, child POMs are expected to override if needed -->
           <excludeFilterFile>${spotbugs.excludeFilterFile}</excludeFilterFile>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.9.0</version>
+            </plugin>
+          </plugins>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -630,7 +630,7 @@
             <plugin>
               <groupId>com.h3xstream.findsecbugs</groupId>
               <artifactId>findsecbugs-plugin</artifactId>
-              <version>1.9.0</version>
+              <version>1.10.1</version>
             </plugin>
           </plugins>
         </configuration>


### PR DESCRIPTION
I added [find-sec-bugs ](https://github.com/find-sec-bugs/find-sec-bugs) plugin to spotbugs. I don't think that it should be merged right away, because there are a lot of findigs in Jenkins. This is here for discussion, if this is useful at all.

But I found for example:
https://github.com/jenkinsci/jenkins/pull/4363