### PR TITLE
Introduce version for spotbugs annotations for re-use in jenkins bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>${spotbus-annotations.version}</version>
+        <version>${spotbugs-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -897,7 +897,7 @@
     <java.level.test>${java.level}</java.level.test>
 
     <spotbugs-maven-plugin.version>4.0.0</spotbugs-maven-plugin.version>
-    <spotbus-annotations.version>4.0.1</spotbus-annotations.version>
+    <spotbugs-annotations.version>4.0.1</spotbugs-annotations.version>
     <!-- Deprecated FindBugs configuration -->
     <findbugs.failOnError>true</findbugs.failOnError>
     <findbugs.threshold>Medium</findbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.0.1</version>
+        <version>${spotbus-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -897,6 +897,7 @@
     <java.level.test>${java.level}</java.level.test>
 
     <spotbugs-maven-plugin.version>4.0.0</spotbugs-maven-plugin.version>
+    <spotbus-annotations.version>4.0.1</spotbus-annotations.version>
     <!-- Deprecated FindBugs configuration -->
     <findbugs.failOnError>true</findbugs.failOnError>
     <findbugs.threshold>Medium</findbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
     <java.level.test>${java.level}</java.level.test>
 
     <spotbugs-maven-plugin.version>4.0.0</spotbugs-maven-plugin.version>
-    <spotbugs-annotations.version>4.0.1</spotbugs-annotations.version>
+    <spotbugs-annotations.version>4.0.2</spotbugs-annotations.version>
     <!-- Deprecated FindBugs configuration -->
     <findbugs.failOnError>true</findbugs.failOnError>
     <findbugs.threshold>Medium</findbugs.threshold>


### PR DESCRIPTION
Introduce version for spotbugs annotations for re-use in jenkins bom.
Follow-Up of: https://github.com/jenkinsci/jenkins/pull/4689