### PR TITLE
Pass `argLine` to Maven Surefire Plugin so that agents can be connected to the tests run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
           <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
-            <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+            <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true ${argLine}</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
I am working on adding code coverage reporting to https://github.com/jenkinsci/jenkinsfile-runner/ . Unfortunately JaCoCo profile cannot run with the default configuration of the Maven Sure Fire plugin. JaCoCo plugin installs the Java agent and passes configuration through `argLine`. This argline gets suppressed by the historical SUREFIRE-1588 patch.

This patch fixes the behavior

