### PR TITLE
Define an empty argline property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -966,5 +966,6 @@
     <maven-license-plugin.version>1.8</maven-license-plugin.version>
     <incrementals-plugin.version>1.2</incrementals-plugin.version>
     <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
+    <argLine />
   </properties>
 </project>


### PR DESCRIPTION
This avoids problems if the argLine doesn't end up getting defined by something else.

This is a follow-on to #138

Without defining the argLine the previous change may break some projects that use this parent. For one example see jenkinsci/remoting#407. Once this is merged in, Remoting can update to the latest parent without needing to define argLine itself.