### PR TITLE
Copy -Pquick-build from plugin-pom 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -893,6 +893,19 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!--  a profile that disables as much testing as possible testing whilst still producing the artifacts -->
+      <id>quick-build</id>
+      <properties>
+        <!-- we can not use maven.test.skip because we may be producing a test jar -->
+        <skipTests>true</skipTests>
+        <spotbugs.skip>true</spotbugs.skip>
+        <enforcer.skip>true</enforcer.skip>
+        <access-modifier-checker.skip>true</access-modifier-checker.skip>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+        <invoker.skip>true</invoker.skip>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>


### PR DESCRIPTION
Porting https://github.com/jenkinsci/plugin-pom/blob/105ec85c7cb014d83f30622aeda6ae8a7e0a86d6/pom.xml#L1434-L1446 as it is used by https://github.com/jglick/jenkins-maven-cd-action/blob/8d95c384dedf1e459b8fe30fb789eb6a5bcf2fd1/run.sh#L4 and so we would need this to be present if we were using JEP-229 on non-plugin repositories.
