### PR TITLE
Generate metadata for reflection on method parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -938,6 +938,9 @@
          Generally it is recommended to use @SuppressFBWarnings annotation unless you want to ignore an entire class of issues -->
     <spotbugs.excludeFilterFile>${findbugs.excludeFilterFile}</spotbugs.excludeFilterFile>
 
+    <!-- Generate metadata for reflection on method parameters -->
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
     


### PR DESCRIPTION
A port of jenkinsci/plugin-pom#415 for the parent POM for Jenkins core and libraries. See stapler/stapler#226 and [the Maven documentation](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#parameters). Once widely adopted, this would allow us to use reflection rather than ASM in Stapler for discovering method parameters.