### PR TITLE
Exclude `servlet-api` from `requireUpperBoundDeps`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,12 @@
                 <requireJavaVersion>
                   <version>[1.${java.level}.0,]</version>
                 </requireJavaVersion>
-                <requireUpperBoundDeps />
+                <requireUpperBoundDeps>
+                  <excludes>
+                    <exclude>javax.servlet:javax.servlet-api</exclude>
+                    <exclude>javax.servlet:servlet-api</exclude>
+                  </excludes>
+                </requireUpperBoundDeps>
                 <enforceBytecodeVersion>
                   <maxJdkVersion>1.${java.level}</maxJdkVersion>
                   <ignoredScopes>


### PR DESCRIPTION
Amends #196. Complements jenkinsci/plugin-pom#456, specifically

https://github.com/jenkinsci/plugin-pom/blob/843c0894e7b8eae9451b6adfe0ac2895d470f512/pom.xml#L540-L541

Without this PR, core cannot be upgraded to the latest snapshot parent POM because of `requireUpperBoundDeps` errors in `servlet-api`.

Tested by building core with the parent POM from this PR.