### PR TITLE
Ignore `jsr305` warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -671,6 +671,7 @@
                 </requireJavaVersion>
                 <requireUpperBoundDeps>
                   <excludes>
+                    <exclude>com.google.code.findbugs:jsr305</exclude>
                     <exclude>javax.servlet:javax.servlet-api</exclude>
                     <exclude>javax.servlet:servlet-api</exclude>
                   </excludes>


### PR DESCRIPTION
`plugin-pom` already has this exclusion, and without this I get annoying errors in some cases like

```
Require upper bound dependencies error for com.google.code.findbugs:jsr305:3.0.1 [provided] paths to dependency are:
+-org.jenkins-ci.main:cli:2.324-SNAPSHOT
  +-com.github.spotbugs:spotbugs-annotations:4.5.0 [provided]
    +-com.google.code.findbugs:jsr305:3.0.1 [provided] (managed) <-- com.google.code.findbugs:jsr305:3.0.2 [provided]
```

CC @jglick 