### PR TITLE
Ban `javax.servlet:servlet-api`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -669,6 +669,14 @@
                 <requireJavaVersion>
                   <version>[1.${java.level}.0,]</version>
                 </requireJavaVersion>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>javax.servlet:servlet-api</exclude>
+                  </excludes>
+                  <includes>
+                    <include>javax.servlet:servlet-api:[0]</include>
+                  </includes>
+                </bannedDependencies>
                 <requireUpperBoundDeps>
                   <excludes>
                     <exclude>com.google.code.findbugs:jsr305</exclude>


### PR DESCRIPTION
`javax.servlet:servlet-api` is a banned dependency, so let's enforce that core and core components don't use it. The only exception to this rule is version 0, which is a custom version that we have deployed to `repo.jenkins-ci.org` which has an empty JAR.