### PR TITLE
[JENKINS-67960] Work around MCOMPILER-346

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -864,6 +864,11 @@
             <configuration>
               <release>${java.level}</release>
               <testRelease>${java.level}</testRelease>
+              <!--
+                Work around MCOMPILER-346.
+                TODO When MCOMPILER-346 is resolved, this should be deleted.
+              -->
+              <forceJavacCompilerUse>true</forceJavacCompilerUse>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
### Background

See [JENKINS-67960](https://issues.jenkins.io/browse/JENKINS-67960) and [MCOMPILER-346](https://issues.apache.org/jira/browse/MCOMPILER-346). I have run into this bug repeatedly while working on Jenkins, most recently in jenkinsci/acceptance-test-harness#733.

### Problem

When compiling Jenkins code with compilation errors with Java 11, [MCOMPILER-346](https://issues.apache.org/jira/browse/MCOMPILER-346) is frequently encountered. If you encounter it with `-source 8`, you get a `NullPointerException`. If you encounter it with `-source 11`, you get an `AssertionError`. Either way, you do not get a readable message with the compilation error. Therefore, you have no idea what you need to fix in order to get the code to compile.

### Solution

TBD. MCOMPILER-346 has remained open since June 28, 2018. I submitted a [Minimal Reproducible Example (MRE)](https://issues.apache.org/jira/browse/MCOMPILER-346?focusedCommentId=17501618&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17501618) hoping that this will help the Maven developers resolve the issue.

### Workaround

In the past, I have worked around this issue by switching back to Java 8. This works with `-source 8`, but it does not work with `-source 11` for obvious reasons. Therefore, a new workaround is needed. I have just discovered a new workaround: running Maven with `-Dmaven.compiler.forceJavacCompilerUse=true`. Until MCOMPILER-346 is fixed, we should enable this workaround by default for all Jenkins builds. Otherwise, people compiling with Java 11 will get strange `NullPointerException`s or `AssertionError`s when their code does not compile rather than a comprehensible error message explaining the source of the compilation error.

### Testing done

Reproduced the failure from jenkinsci/acceptance-test-harness#733 locally. Then upgraded the POM to the one from this PR and could no longer reproduce the issue. Instead, I got a comprehensible error message.