### PR TITLE
Sideport of JENKINS-54842 to `pom`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
     <!-- By default only check remote repositories once per week -->
     <maven.repository.update.freqency>interval:10080</maven.repository.update.freqency>
 
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.testSource>1.8</maven.compiler.testSource>
+    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+    <!-- Generate metadata for reflection on method parameters -->
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+
     <spotbugs-maven-plugin.version>4.6.0.0</spotbugs-maven-plugin.version>
     <spotbugs-annotations.version>4.6.0</spotbugs-annotations.version>
     <!-- Whether the build should fail if SpotBugs finds any error. -->
@@ -100,9 +107,6 @@
     <!-- Defines an optional SpotBugs excludes file.
          Generally it is recommended to use @SuppressFBWarnings annotation unless you want to ignore an entire class of issues -->
     <spotbugs.excludeFilterFile />
-
-    <!-- Generate metadata for reflection on method parameters -->
-    <maven.compiler.parameters>true</maven.compiler.parameters>
 
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
@@ -827,16 +831,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <testSource>1.8</testSource>
-          <testTarget>1.8</testTarget>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-eclipse-plugin</artifactId>
       </plugin>
@@ -849,22 +843,13 @@
       <activation>
         <jdk>[1.9,)</jdk>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <release>8</release>
-              <testRelease>8</testRelease>
-              <!--
-                Work around MCOMPILER-346.
-                TODO When MCOMPILER-346 is resolved, this should be deleted.
-              -->
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.testRelease>8</maven.compiler.testRelease>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+        <!-- Work around openjdk/jdk11u-dev#919. TODO When we upgrade to OpenJDK 11.0.16, this should be deleted. -->
+        <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
+      </properties>
     </profile>
     <profile>
       <id>always-check-remote-repositories</id>


### PR DESCRIPTION
Straightforward sideport of https://github.com/jenkinsci/plugin-pom/pull/523 from `plugin-pom` to `pom`. The main change of substance here is that we are now skipping Animal Sniffer when `release` is set (i.e., when building with a Java 9 or later compiler, even when we build Java 8 bytecode). The switch from XML configuration to properties is not necessary in this repository as it was in https://github.com/jenkinsci/plugin-pom/pull/523 (there is no `Initializer` mojo manipulating these values for core or core components), but I think there is value in keeping these two repositories (which are largely copypasta of each other) as similar as possible in order to make it easier to sideport other changes in the future without merge conflicts.