### PR TITLE
Avoid unnecessary defining and clearing of properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,6 @@
     <!-- By default only check remote repositories once per week -->
     <maven.repository.update.freqency>interval:10080</maven.repository.update.freqency>
 
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.testSource>1.8</maven.compiler.testSource>
-    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
 
@@ -839,9 +835,21 @@
 
   <profiles>
     <profile>
-      <id>jdk-above-9</id>
+      <id>jdk-8-and-below</id>
       <activation>
-        <jdk>[1.9,)</jdk>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.testSource>1.8</maven.compiler.testSource>
+        <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+      </properties>
+    </profile>
+    <profile>
+      <id>jdk-9-and-above</id>
+      <activation>
+        <jdk>[9,)</jdk>
       </activation>
       <properties>
         <!-- When compiling with a Java 9+ compiler, we always rely on "release" in favor of "source" and "target", even when compiling to Java 8 bytecode. -->
@@ -849,11 +857,6 @@
         <maven.compiler.testRelease>8</maven.compiler.testRelease>
         <!-- "release" serves the same purpose as Animal Sniffer. -->
         <animal.sniffer.skip>true</animal.sniffer.skip>
-        <!-- While it does not hurt to have these set to the Java specification version, it is also not needed when "release" is in use. -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
-        <maven.compiler.testSource combine.self="override" />
-        <maven.compiler.testTarget combine.self="override" />
         <!-- Work around openjdk/jdk11u-dev#919. TODO When we upgrade to OpenJDK 11.0.16, this should be deleted. -->
         <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
       </properties>


### PR DESCRIPTION
Fixup to https://github.com/jenkinsci/pom/pull/248: if we avoid defining the properties for Java 9+, we don't have to clear them.