### PR TITLE
Fix Maven HPI plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
         <plugin>
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-hpi-plugin</artifactId>
-          <version>${maven-hpi-plugin.version}</version>
+          <version>${hpi-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.localizer</groupId>


### PR DESCRIPTION
Fix an error introduced in #259: I renamed the property in one place but not the other.