### PR TITLE
Remove `source=8` from Javadoc configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,6 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
-            <source>8</source>
             <locale>en_US</locale>
           </configuration>
         </plugin>


### PR DESCRIPTION
Amends #209. Setting `source=8` is wrong now that we are requiring Java 11. Furthermore, based on my reading of `AbstractJavadocMojo` it is dead code: whenever `release` is set, it is always used in place of `source` in that class. And we are (implicitly) setting `release` (to the correct value of 11, no less!) because `release` defaults to the value of the `maven.compiler.release` property, which we are setting to 11. So we are implicitly setting `release`, which means `source` is unused, which means it is dead code, which means it should be deleted.