### PR TITLE
`-Xdoclint:all,-missing`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
+            <doclint>all,-missing</doclint>
             <locale>en_US</locale>
           </configuration>
         </plugin>


### PR DESCRIPTION
Matching https://github.com/jenkinsci/plugin-pom/pull/356 since I noticed in https://github.com/jenkinsci/stapler/pull/370 that it is hard to see the actual diff for all the silly Javadoc warnings.
