### PR TITLE
[JENKINS-68919] Redirect test output to file when running all tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,17 @@
 
   <profiles>
     <profile>
+      <id>all-tests</id>
+      <activation>
+        <property>
+          <name>!test</name>
+        </property>
+      </activation>
+      <properties>
+        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
+      </properties>
+    </profile>
+    <profile>
       <id>always-check-remote-repositories</id>
       <properties>
         <maven.repository.update.freqency>always</maven.repository.update.freqency>


### PR DESCRIPTION
Consistent with https://github.com/jenkinsci/plugin-pom/blob/ac96d2394082c1ea3808ad59e789712162a922f9/pom.xml#L1160-L1170=

Tested in core (verified that `executable.MainTest` stopped spamming logs except when running with `-Dtest=executable.MainTest`):

```
diff --git a/core/pom.xml b/core/pom.xml
index 569d56a603..49f0d46bec 100644
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -798,17 +798,6 @@ THE SOFTWARE.
         <spotbugs.failOnError>true</spotbugs.failOnError>
       </properties>
     </profile>
-    <profile>
-      <id>all-tests</id>
-      <activation>
-        <property>
-          <name>!test</name>
-        </property>
-      </activation>
-      <properties>
-        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-      </properties>
-    </profile>
     <profile>
       <id>enable-jacoco</id>
       <build>
diff --git a/pom.xml b/pom.xml
index ae8cecdb55..fb539c5424 100644
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.78</version>
+    <version>1.79-SNAPSHOT</version>
     <relativePath />
   </parent>
 
diff --git a/test/pom.xml b/test/pom.xml
index 9e6dbbc3f2..35f11afba1 100644
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -335,7 +335,6 @@ THE SOFTWARE.
         </property>
       </activation>
       <properties>
-        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <surefire.rerunFailingTestsCount>4</surefire.rerunFailingTestsCount>
         <surefire.skipAfterFailureCount>100</surefire.skipAfterFailureCount>
       </properties>
```