### PR TITLE
Upgrade Maven AntRun plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,7 @@
     <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
     <kohsuke-gmaven-plugin.version>1.0-rc-5-patch-2</kohsuke-gmaven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-    <maven-antrun-extended-plugin.version>1.43</maven-antrun-extended-plugin.version>
-    <maven-antrun-plugin.version>1.3</maven-antrun-plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.4.1</maven-assembly-plugin.version>
     <maven-changelog-plugin.version>2.3</maven-changelog-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
@@ -222,6 +221,10 @@
     <defaultGoal>install</defaultGoal>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>${maven-antrun-plugin.version}</version>
+        </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven-assembly-plugin.version}</version>
@@ -450,11 +453,6 @@
           <groupId>org.jvnet.localizer</groupId>
           <artifactId>localizer-maven-plugin</artifactId>
           <version>${localizer-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
-          <artifactId>maven-antrun-extended-plugin</artifactId>
-          <version>${maven-antrun-extended-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.sorcerer</groupId>


### PR DESCRIPTION
Whatever `maven-antrun-extended-plugin` is, it hasn't been updated in a decade. Better to remove it and for any consumers that still need it to remove their dependency or carry it themselves independently of the parent POM. In addition, we upgrade `maven-antrun-plugin` to the latest version, which is also consistent with the plugin POM. To test this I verified that core could be built with these changes and confirmed `maven-antrun-plugin` 3.1.0 could run the core build.