### PR TITLE
Make it easier to use a different JVM target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -730,7 +730,7 @@
                 </requirePluginVersions>
                 -->
                 <requireJavaVersion>
-                  <version>[{javaTarget},]</version>
+                  <version>[${javaTarget},]</version>
                 </requireJavaVersion>
                 <bannedDependencies>
                   <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,9 @@
     <!-- By default only check remote repositories once per week -->
     <maven.repository.update.freqency>interval:10080</maven.repository.update.freqency>
 
-    <maven.compiler.release>11</maven.compiler.release>
-    <maven.compiler.testRelease>11</maven.compiler.testRelease>
+    <javaTarget>11</javaTarget>
+    <maven.compiler.release>${javaTarget}</maven.compiler.release>
+    <maven.compiler.testRelease>${javaTarget}</maven.compiler.testRelease>
     <!-- Work around openjdk/jdk11u-dev#919. TODO When we upgrade to OpenJDK 11.0.16, this should be deleted. -->
     <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
     <!-- Generate metadata for reflection on method parameters -->
@@ -729,7 +730,7 @@
                 </requirePluginVersions>
                 -->
                 <requireJavaVersion>
-                  <version>[11,]</version>
+                  <version>[{javaTarget},]</version>
                 </requireJavaVersion>
                 <bannedDependencies>
                   <excludes>
@@ -749,7 +750,7 @@
                   </excludes>
                 </requireUpperBoundDeps>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>11</maxJdkVersion>
+                  <maxJdkVersion>${javaTarget}</maxJdkVersion>
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>


### PR DESCRIPTION
Whilst Jenkins defaults will now be java11 some libraries may want to
stay on java8.

Doing so makes backports of any issues much easier (hopefully not
needed!) and the library can take advantage of all the updated plugins
with their fixes.

Whilst this is less than optimal for java8 as it still required a java9+
JVM to be used to compile (as that was when the `release` flag was
introduced) it is much better than either
*  pinning the parent to 1.76 (the last supporting java8)
* having to overwrite all the properties to remove the maven.compiler.release and testRelease ones as well as
overwriting the enforcer configurations (albeit this is simplier with
combine.children)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
