### PR TITLE
Use JUnit BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,9 +179,11 @@
         <version>${spotbugs-annotations.version}</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.9.0</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
We import this in the plugin POM, so might as well import it here for consistency. It includes both JUnit 4 and JUnit 5. Once adopted by downstream consumers, they can stop pulling in the JUnit BOM themselves which should result in some code deduplication.