### PR TITLE
Add correct archive URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,24 +18,28 @@
       <name>Jenkins advisories list</name>
       <subscribe>jenkinsci-advisories+subscribe@googlegroups.com</subscribe>
       <unsubscribe>jenkinsci-advisories+unsubscribe@googlegroups.com</unsubscribe>
+      <archive>https://groups.google.com/g/jenkinsci-advisories</archive>
     </mailingList>
     <mailingList>
       <name>Jenkins developer discussion list</name>
       <subscribe>jenkinsci-dev+subscribe@googlegroups.com</subscribe>
       <unsubscribe>jenkinsci-dev+unsubscribe@googlegroups.com</unsubscribe>
       <post>jenkinsci-dev@googlegroups.com</post>
+      <archive>https://groups.google.com/g/jenkinsci-dev</archive>
     </mailingList>
     <mailingList>
       <name>Jenkins user discussion list</name>
       <subscribe>jenkinsci-users+subscribe@googlegroups.com</subscribe>
       <unsubscribe>jenkinsci-users+unsubscribe@googlegroups.com</unsubscribe>
       <post>jenkinsci-users@googlegroups.com</post>
+      <archive>https://groups.google.com/g/jenkinsci-users</archive>
     </mailingList>
     <mailingList>
       <name>Jenkins Japanese user discussion list</name>
       <subscribe>jenkinsci-ja+subscribe@googlegroups.com</subscribe>
       <unsubscribe>jenkinsci-ja+unsubscribe@googlegroups.com</unsubscribe>
       <post>jenkinsci-ja@googlegroups.com</post>
+      <archive>https://groups.google.com/g/jenkinsci-ja</archive>
     </mailingList>
   </mailingLists>
 


### PR DESCRIPTION
https://github.com/jenkinsci/pom/pull/302 removed the archive URLs. This adds the currently working archive URLs back.

It's unclear to me what the purpose of having this in the pom is (other than site builds) but since the entries still exist, they should be complete.

There's more wrong here, e.g. the differences between the pom and https://www.jenkins.io/mailing-lists/ are staggering, but one step at a time.