### PR TITLE
Remove `oleg-nenashev` from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-  reviewers:
-  - oleg-nenashev


### PR DESCRIPTION
@oleg-nenashev is no longer active in this repository.