### PR TITLE
Define Enforcer Java version in terms of `maven.compiler.release`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -735,7 +735,7 @@
                 </requirePluginVersions>
                 -->
                 <requireJavaVersion>
-                  <version>[11,]</version>
+                  <version>[${maven.compiler.release},]</version>
                 </requireJavaVersion>
                 <bannedDependencies>
                   <excludes>
@@ -755,7 +755,7 @@
                   </excludes>
                 </requireUpperBoundDeps>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>11</maxJdkVersion>
+                  <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>


### PR DESCRIPTION
Alternative to #297. This matches the Maven Javadoc plugin, which [uses the values of the `maven.compiler.source` and `maven.compiler.release` properties if defined](https://github.com/apache/maven-javadoc-plugin/blob/5b61ee915298b51a273bd88612fb346ac639d9e0/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java#L817-L831). This alternative eliminates my two main objections to #297:

- It only works for Java 9+, thus eliminating the negative incentive to stay on Java 8
- It does not define a new API for consumers, thus not implicitly committing us to supporting arbitrary future Java versions via this mechanism. Rather this PR just makes it less likely that people who are using the existing Maven API will have  trouble with Enforcer.

I tested this by compiling Jenkins core with `-Dmaven.compiler.release=19` and `-Dmaven.compiler.testRelease=19` and (after dealing with unrelated bugs) ensured that Java 19 bytecode got generated.

Closes #297.