### PR TITLE
Ban log4j 1.x from core components at build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -740,6 +740,7 @@
                 <bannedDependencies>
                   <excludes>
                     <exclude>javax.servlet:servlet-api</exclude>
+                    <exclude>log4j:log4j</exclude>
                     <!-- CVE-2021-44228 -->
                     <exclude>org.apache.logging.log4j:*:(,2.15.0-rc1]</exclude>
                   </excludes>


### PR DESCRIPTION
Consistent with https://github.com/jenkinsci/plugin-pom/blob/c07f8eba1f5fb6dec05096fad781303635833209/pom.xml#L570-L571. Can be done for core components now that jenkinsci/jenkins#7028 has landed. To test this, I successfully ran `mvn clean verify -DskipTests` in Jenkins core with these changes.