### PR TITLE
Define a standard SpotBugs exclude filter file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -675,6 +675,11 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
+          <!--
+            Do not define "excludeFilterFile" here, as it will force consumers to provide a file.
+            Instead, we configure this below in a profile conditionally activated based on the
+            presence of this file.
+          -->
           <xmlOutput>true</xmlOutput>
           <spotbugsXmlOutput>false</spotbugsXmlOutput>
           <plugins>
@@ -812,6 +817,30 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>spotbugs-exclusion-file</id>
+      <activation>
+        <file>
+          <exists>${maven.multiModuleProjectDirectory}/src/spotbugs/excludesFilter.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotbugs</id>
+                <configuration>
+                  <excludeFilterFile>${maven.multiModuleProjectDirectory}/src/spotbugs/excludesFilter.xml</excludeFilterFile>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Picking up https://github.com/jenkinsci/plugin-pom/blob/efa3afff274c907f0404cda9bdf91195ba63cd6c/pom.xml#L1138-L1161 from the plugin POM. To test this I removed `<spotbugs.excludeFilterFile>` from Jenkins core, observed SpotBugs errors as expected, then observed that the errors went away after I renamed `src/spotbugs/spotbugs-excludes.xml` to `src/spotbugs/excludesFilter.xml`.