### PR TITLE
Make SpotBugs configuration consistent with `plugin-pom`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -675,13 +675,6 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
-          <!--
-            Do not define "excludeFilterFile" here, as it will force consumers to provide a file.
-            Instead, we configure this below in a profile conditionally activated based on the
-            presence of this file.
-          -->
-          <xmlOutput>true</xmlOutput>
-          <spotbugsXmlOutput>false</spotbugsXmlOutput>
           <plugins>
             <plugin>
               <groupId>com.h3xstream.findsecbugs</groupId>
@@ -697,6 +690,15 @@
               <goal>check</goal>
             </goals>
             <phase>verify</phase>
+            <configuration>
+              <!--
+                Do not define "excludeFilterFile" here, as it will force consumers to provide a file.
+                Instead, we configure this below in a profile conditionally activated based on the
+                presence of this file.
+              -->
+              <xmlOutput>true</xmlOutput>
+              <spotbugsXmlOutput>false</spotbugsXmlOutput>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Consistent with https://github.com/jenkinsci/plugin-pom/blob/7a900a501a29781b2c3b2b2a1b9fbcc6aecb5862/pom.xml#L684-L705. To test this change I ran a core build with `mvn clean verify -DskipTests` and verified that the SpotBugs XML files were generated as before.