### PR TITLE
Remove `org.mortbay.jetty:maven-jetty-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
     <maven-install-plugin.version>3.0.1</maven-install-plugin.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>
     <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
     <localizer-maven-plugin.version>1.31</localizer-maven-plugin.version>
     <maven-pmd-plugin.version>3.19.0</maven-pmd-plugin.version>
@@ -643,11 +642,6 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>maven-jetty-plugin</artifactId>
-          <version>${maven-jetty-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>com.cloudbees</groupId>


### PR DESCRIPTION
`org.mortbay.jetty:maven-jetty-plugin` has not been released since 2008 and was removed in `plugin-pom` in jenkinsci/plugin-pom@24b09578ef07f5b759283d6778f80e479826c6a7. I am not aware of any usages in Jenkins core components.