### PR TITLE
Remove `maven-sorcerer-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,6 @@
     <maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-    <maven-sorcerer-plugin.version>0.8</maven-sorcerer-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-stapler-plugin.version>1.20</maven-stapler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
@@ -458,11 +457,6 @@
           <groupId>org.jvnet.localizer</groupId>
           <artifactId>localizer-maven-plugin</artifactId>
           <version>${localizer-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.jvnet.sorcerer</groupId>
-          <artifactId>maven-sorcerer-plugin</artifactId>
-          <version>${maven-sorcerer-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
Sorcerer does not work with Java 11 and we ripped it out of Jenkins core in jenkinsci/jenkins#5960.