### PR TITLE
Remove `gmaven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,10 @@
     <cargo-maven2-plugin.version>1.8.5</cargo-maven2-plugin.version>
     <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-    <gmaven-plugin.version>1.5-jenkins-3</gmaven-plugin.version>
     <gwt-maven-plugin.version>2.10.0</gwt-maven-plugin.version>
     <hpi-plugin.version>3.35</hpi-plugin.version>
     <javancss-maven-plugin.version>2.1</javancss-maven-plugin.version>
     <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
-    <kohsuke-gmaven-plugin.version>1.0-rc-5-patch-2</kohsuke-gmaven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
@@ -373,11 +371,6 @@
           <version>${cargo-maven2-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.gmaven</groupId>
-          <artifactId>gmaven-plugin</artifactId>
-          <version>${gmaven-plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>apt-maven-plugin</artifactId>
           <version>${apt-maven-plugin.version}</version>
@@ -570,22 +563,6 @@
                 </pluginExecution>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId>org.codehaus.gmaven</groupId>
-                    <artifactId>gmaven-plugin</artifactId>
-                    <versionRange>[1.3,)</versionRange>
-                    <goals>
-                      <goal>compile</goal>
-                      <goal>testCompile</goal>
-                      <goal>generateStubs</goal>
-                      <goal>generateTestStubs</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
                     <groupId>org.jvnet.hudson.tools</groupId>
                     <artifactId>maven-encoding-plugin</artifactId>
                     <versionRange>[1.1,)</versionRange>
@@ -649,11 +626,6 @@
           <groupId>org.jvnet.localizer</groupId>
           <artifactId>localizer-maven-plugin</artifactId>
           <version>${localizer-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.kohsuke.gmaven</groupId>
-          <artifactId>gmaven-plugin</artifactId>
-          <version>${kohsuke-gmaven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
See #42. A GItHub code search for `user:jenkinsci path:pom.xml "gmaven-plugin"` only yielded results in plugins (not affected by changes to this POM) and https://github.com/jenkinsci/lib-groovy-guice-binder/blob/ed3447b4ed59aa487cda6690072211c1678de3c6/pom.xml#L16-L30 (which declares an explicit version, so it is also not affected by changes to this POM), so this plugin is safe to remove. To test this change I successfully built Jenkins core with the changes from this PR (modulo having to fix a SpotBugs warning from an unrelated PR).