### PR TITLE
Remove `forceJavacCompilerUse` workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,6 @@
 
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.testRelease>11</maven.compiler.testRelease>
-    <!-- Work around openjdk/jdk11u-dev#919. TODO When we upgrade to OpenJDK 11.0.16, this should be deleted. -->
-    <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
 


### PR DESCRIPTION
This workaround was needed prior to the release of OpenJDK 11.0.16. We're now running 11.0.17 on Jenkins project infrastructure, so this workaround is no longer necessary.