### PR TITLE
Inline Maven property `incrementals.url` for Maven 4 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
 
     <mockito.version>5.0.0</mockito.version>
@@ -842,7 +841,7 @@
             <enabled>false</enabled>
           </snapshots>
           <id>incrementals</id>
-          <url>${incrementals.url}</url>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
         </repository>
       </repositories>
       <pluginRepositories>
@@ -851,7 +850,7 @@
             <enabled>false</enabled>
           </snapshots>
           <id>incrementals</id>
-          <url>${incrementals.url}</url>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
         </pluginRepository>
       </pluginRepositories>
     </profile>
@@ -923,7 +922,7 @@
       <distributionManagement>
         <repository>
           <id>incrementals</id>
-          <url>${incrementals.url}</url>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
         </repository>
       </distributionManagement>
       <build>


### PR DESCRIPTION
Side-port of https://github.com/jenkinsci/plugin-pom/pull/666 to the POM for core and core components.