### PR TITLE
Consolidate `maven-surefire-plugin.version` and `maven-surefire-report-plugin.version`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,6 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-stapler-plugin.version>1.22</maven-stapler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>3.0.0-M8</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
     <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
     <taglist-maven-plugin.version>3.0.0</taglist-maven-plugin.version>
@@ -350,7 +349,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>${maven-surefire-report-plugin.version}</version>
+          <version>${maven-surefire-plugin.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-war-plugin</artifactId>


### PR DESCRIPTION
These two Maven plugins live in the same Git repository and are released in lockstep, so it does not make sense to use a different property for each one. This PR simplifies the version management by using a single property for both.