### PR TITLE
Use a name for the Stapler plugin property that is consistent with `plugin-pom`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <maven-stapler-plugin.version>1.22</maven-stapler-plugin.version>
+    <stapler-plugin.version>1.22</stapler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>3.0.0-M8</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
@@ -621,7 +621,7 @@
         <plugin>
           <groupId>org.kohsuke.stapler</groupId>
           <artifactId>maven-stapler-plugin</artifactId>
-          <version>${maven-stapler-plugin.version}</version>
+          <version>${stapler-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
`plugin-pom` uses the property name `stapler-plugin.version` for the version of the Stapler plugin. This PR makes `jenkinsci/pom` consistent by using the same name here as well.