### PR TITLE
Remove obsolete Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,27 +94,17 @@
     <mockito.version>5.0.0</mockito.version>
 
     <!-- Define all plugin versions as properties so individual hierarchies can easily override -->
-    <apt-maven-plugin.version>1.0-alpha-5</apt-maven-plugin.version>
-    <axistools-maven-plugin.version>1.4</axistools-maven-plugin.version>
-    <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-    <cargo-maven2-plugin.version>1.8.5</cargo-maven2-plugin.version>
-    <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-    <gwt-maven-plugin.version>2.10.0</gwt-maven-plugin.version>
     <hpi-plugin.version>3.38</hpi-plugin.version>
-    <javancss-maven-plugin.version>2.1</javancss-maven-plugin.version>
-    <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
-    <maven-changelog-plugin.version>2.3</maven-changelog-plugin.version>
     <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
-    <maven-doap-plugin.version>1.2</maven-doap-plugin.version>
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
@@ -122,11 +112,9 @@
     <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
     <localizer-maven-plugin.version>1.31</localizer-maven-plugin.version>
     <maven-pmd-plugin.version>3.20.0</maven-pmd-plugin.version>
     <maven-project-info-reports-plugin.version>3.4.2</maven-project-info-reports-plugin.version>
-    <maven-reactor-plugin.version>1.1</maven-reactor-plugin.version>
     <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
@@ -136,10 +124,7 @@
     <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>3.0.0-M8</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
-    <openjpa-maven-plugin.version>1.2</openjpa-maven-plugin.version>
-    <taglist-maven-plugin.version>3.0.0</taglist-maven-plugin.version>
     <versions-maven-plugin.version>2.14.2</versions-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
     <maven-license-plugin.version>1.15</maven-license-plugin.version>
     <incrementals-plugin.version>1.4</incrementals-plugin.version>
     <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
@@ -246,10 +231,6 @@
           <version>${maven-assembly-plugin.version}</version>
         </plugin>
         <plugin>
-          <artifactId>maven-changelog-plugin</artifactId>
-          <version>${maven-changelog-plugin.version}</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven-checkstyle-plugin.version}</version>
         </plugin>
@@ -268,10 +249,6 @@
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven-deploy-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-doap-plugin</artifactId>
-          <version>${maven-doap-plugin.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-eclipse-plugin</artifactId>
@@ -306,20 +283,12 @@
           </configuration>
         </plugin>
         <plugin>
-          <artifactId>maven-jxr-plugin</artifactId>
-          <version>${maven-jxr-plugin.version}</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${maven-pmd-plugin.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>${maven-project-info-reports-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-reactor-plugin</artifactId>
-          <version>${maven-reactor-plugin.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
@@ -357,21 +326,6 @@
           <version>${maven-war-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.cargo</groupId>
-          <artifactId>cargo-maven2-plugin</artifactId>
-          <version>${cargo-maven2-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>apt-maven-plugin</artifactId>
-          <version>${apt-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>axistools-maven-plugin</artifactId>
-          <version>${axistools-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-maven-plugin.version}</version>
@@ -392,53 +346,8 @@
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
-          <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>${buildnumber-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>cobertura-maven-plugin</artifactId>
-          <version>${cobertura-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>gwt-maven-plugin</artifactId>
-          <version>${gwt-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>javancss-maven-plugin</artifactId>
-          <version>${javancss-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>jdepend-maven-plugin</artifactId>
-          <version>${jdepend-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>openjpa-maven-plugin</artifactId>
-          <version>${openjpa-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>taglist-maven-plugin</artifactId>
-          <version>${taglist-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>versions-maven-plugin</artifactId>
-          <version>${versions-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>xml-maven-plugin</artifactId>
-          <version>${xml-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
This POM includes a number of Maven plugins that are not present in the plugin POM, are not consumed by Jenkins core or any Jenkins core components, and which are obsolete and have not been released in years. This is a maintenance burden, so this PR removes them. In the unlikely case that any consumers still needs one of these Maven plugins, they can declare its version themselves rather than getting it from the parent POM. To test this PR I successfully compiled Jenkins core with these changes.