### PR TITLE
Sort version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,6 @@
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
 
-    <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
-    <spotbugs-annotations.version>4.7.3</spotbugs-annotations.version>
-
     <!--
       The MS_EXPOSE_REP, EI_EXPOSE_REP, EI_EXPOSE_REP2, EI_EXPOSE_STATIC_REP2, MS_EXPOSE_BUF,
       EI_EXPOSE_BUF, EI_EXPOSE_STATIC_BUF2, and EI_EXPOSE_BUF2 bug patterns are noisy and create
@@ -90,13 +87,13 @@
 
     <scmTag>HEAD</scmTag>
 
-    <mockito.version>5.0.0</mockito.version>
-
-    <!-- Define all plugin versions as properties so individual hierarchies can easily override -->
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <hpi-plugin.version>3.38</hpi-plugin.version>
+    <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
+    <incrementals-plugin.version>1.4</incrementals-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
+    <localizer-maven-plugin.version>1.31</localizer-maven-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
@@ -109,9 +106,9 @@
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-help-plugin.version>3.3.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
-    <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <localizer-maven-plugin.version>1.31</localizer-maven-plugin.version>
+    <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
+    <maven-license-plugin.version>1.15</maven-license-plugin.version>
     <maven-pmd-plugin.version>3.20.0</maven-pmd-plugin.version>
     <maven-project-info-reports-plugin.version>3.4.2</maven-project-info-reports-plugin.version>
     <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
@@ -119,13 +116,13 @@
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <stapler-plugin.version>1.22</stapler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
+    <mockito.version>5.0.0</mockito.version>
+    <spotbugs-annotations.version>4.7.3</spotbugs-annotations.version>
+    <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
+    <stapler-plugin.version>1.22</stapler-plugin.version>
     <versions-maven-plugin.version>2.14.2</versions-maven-plugin.version>
-    <maven-license-plugin.version>1.15</maven-license-plugin.version>
-    <incrementals-plugin.version>1.4</incrementals-plugin.version>
-    <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
The list of version properties is easier to read and edit when it is kept in sorted order, like that in `plugin-pom`. Having it in sorted order also makes it easier to check how many tiny differences remain between these two POMs.