### PR TITLE
Remove unnecessary default group ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -659,7 +659,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
             <executions>
               <execution>
@@ -671,7 +670,6 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <executions>
               <execution>


### PR DESCRIPTION
Elsewhere in this POM (and in the logic for this profile in the plugin parent POM), the default `groupId` of `org.apache.maven.plugins` is omitted, so omit it here as well for both internal consistency and consistency with the logic for this profile in the plugin parent POM.