### PR TITLE
Remove unnecessary customization of remote repository update frequency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,6 @@
   </distributionManagement>
 
   <properties>
-    <!-- By default only check remote repositories once per week -->
-    <maven.repository.update.freqency>interval:10080</maven.repository.update.freqency>
-
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.testRelease>11</maven.compiler.testRelease>
     <!-- Generate metadata for reflection on method parameters -->


### PR DESCRIPTION
The Maven default is once per day and the plugin parent POM does not customize this. This parent POM customizes it to once a week. I see no need for this customization. Removing it brings us closer to both the Maven defaults and the plugin parent POM.