### PR TITLE
Remove `defaultGoal`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,6 @@
   </pluginRepositories>
 
   <build>
-    <defaultGoal>install</defaultGoal>
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
This isn't in the plugin POM and I see no reason why anyone should ever be running Maven without specifying a goal. Seems simpler to remove this bizarre customization and stick with the Maven default (and Jenkins plugin default) of forcing consumers to specify a goal.