### PR TITLE
Define `releaseProfiles` in `<plugins>` section rather than `<pluginManagement>` section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,9 +284,6 @@
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
           <version>${maven-release-plugin.version}</version>
-          <configuration>
-            <releaseProfiles>!consume-incrementals,jenkins-release</releaseProfiles>
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-remote-resources-plugin</artifactId>
@@ -645,6 +642,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-eclipse-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <releaseProfiles>jenkins-release,!consume-incrementals</releaseProfiles>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Almost all actual plugin configuration in this POM happens in the `<plugins>` section rather than the `<pluginManagement>` section, which is mostly used to just define versions. This PR makes `maven-release-plugin` internally consistent within this repository. As a bonus it matches the way it is done in the plugin POM as well. We also swapped the order of the two elements in the list to match the order in `plugin-pom`.