### PR TITLE
Eliminate some pointless inconsistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
       </properties>
     </profile>
     <profile>
-      <!-- see JEP-305 -->
+      <!-- JEP-305 -->
       <id>consume-incrementals</id>
       <repositories>
         <repository>
@@ -763,8 +763,6 @@
             <version>1.3.0</version>
             <configuration>
               <updatePomFile>true</updatePomFile>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-              <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
             </configuration>
             <executions>
               <execution>
@@ -775,6 +773,8 @@
                 <phase>process-resources</phase>
                 <configuration>
                   <flattenMode>oss</flattenMode>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
                 </configuration>
               </execution>
             </executions>
@@ -826,6 +826,7 @@
       </distributionManagement>
       <build>
         <plugins>
+          <!-- Copied from jenkins-release: -->
           <plugin>
             <artifactId>maven-source-plugin</artifactId>
             <executions>


### PR DESCRIPTION
Eliminate some pointless inconsistency between this POM and the plugin POM by syncing some comments and moving some configuration from one block to another. It doesn't matter which block the configuration is in, as only one goal was being executed. This was effectively a mistake made when the change was first side-ported.