### PR TITLE
Fix `requireJavaVersion` range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -584,7 +584,7 @@
                 </requirePluginVersions>
                 -->
                 <requireJavaVersion>
-                  <version>[${maven.compiler.release},]</version>
+                  <version>[${maven.compiler.release},)</version>
                 </requireJavaVersion>
                 <bannedDependencies>
                   <excludes>


### PR DESCRIPTION
The use of a comma followed by a square bracket is consistent with neither [the version range specification](https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html) nor https://github.com/jenkinsci/plugin-pom/pull/89. This PR makes it consistent with both.