### PR TITLE
Remove unnecessary `enforceBytecodeVersion` excludes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,11 +609,6 @@
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
-                  <excludes>
-                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
-                    <exclude>com.github.spotbugs:spotbugs-annotations</exclude>
-                    <exclude>com.google.code.findbugs:annotations</exclude>
-                  </excludes>
                   <!-- To add exclusions in a child POM, use:
                   <plugin>
                       <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
I can't see a reason for these excludes, since our bytecode version is Java 11 and these libraries are for older Java versions. To test this I successfully compiled Jenkins core with these changes.