### PR TITLE
Ban `javax.servlet:servlet-api` version 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,9 +593,6 @@
                     <!-- CVE-2021-44228 -->
                     <exclude>org.apache.logging.log4j:*:(,2.15.0-rc1]</exclude>
                   </excludes>
-                  <includes>
-                    <include>javax.servlet:servlet-api:[0]</include>
-                  </includes>
                 </bannedDependencies>
                 <requireUpperBoundDeps>
                   <excludes>


### PR DESCRIPTION
As of jenkinsci/jenkins#7478 we no longer have `javax.servlet:servlet-api` version 0 in our dependency tree, so we can now clean up this logic and ban all versions of it rather than banning all versions except version 0. To test this I compiled Jenkins core with these changes.