### PR TITLE
Add default specification entries, default implementation entries, and Git hash to `MANIFEST.MF`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -553,6 +553,7 @@
           <archive>
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
             </manifest>
             <manifestEntries>
               <Implementation-Build>${buildNumber}</Implementation-Build>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <scmTag>HEAD</scmTag>
 
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
+    <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <hpi-plugin.version>3.42</hpi-plugin.version>
     <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
@@ -333,6 +334,11 @@
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>${buildnumber-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec-maven-plugin.version}</version>
         </plugin>
@@ -523,6 +529,51 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <configuration>
+          <doCheck>true</doCheck>
+          <failTheBuild>false</failTheBuild>
+          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>create</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+            <manifestEntries>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+            <manifestEntries>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>


### PR DESCRIPTION
For the Launchable work, we need a way to get the commit hash from a given artifact in order to define a Launchable build. While this can be derived at runtime by dereferencing the tag back to a commit using the GitHub API, it is simpler to bake this information into the relevant artifact in the first place. This PR adds the following to `MANIFEST.MF` for all core component `.jar` files (including shaded JARs) and `.war` files:

- `Specification-Title`: `${project.name}`
- `Specification-Version`: ${MAJOR.MINOR}`
- `Implementation-Title`: `${project.description}`
- `Implementation-Version`: `${project.version}`
- `Implementation-Build`: Git hash

The last of these is not part of the default implementation entries but is provided by [Build Number Maven Plugin](https://www.mojohaus.org/buildnumber-maven-plugin/usage.html). We use the name `Implementation-Build` since it is somewhat standardized by the example linked in the previous sentence.

I tested this in Jenkins core, `version-number`, and Remoting, by building JARs, shaded JARs, and WARs (both a Jenkins core JAR and a Jenkins core WAR) and verifying that they all had `Implementation-Title`, `Implementation-Version`, and `Implementation-Build` set appropriately. I also verified that this allowed me to remove the custom setting of `Implementation-Version` from `jenkinsci/jenkins/war/pom.xml` (this is handled now by `addDefaultImplementationEntries`) and the ``buildnumber-maven-plugin` configuration from `plugin-compat-tester` (this is now standard configuration for all Jenkins components).

Once this is merged I want to get the same change in for plugins. Plugins never have WAR packaging, but they do have HPI packaging which creates both a `.jar` and a `.hpi` file (with the `.jar` file inside of the `.hpi` file). The recent work done by @jtnord and myself has added a `Plugin-GitHash` entry to the `MANIFEST.MF` file here, but I want to rename that to `Implementation-Build` for consistency with this PR.