### PR TITLE
Remove `spotless.check.skip` from `quick-build profile`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -962,7 +962,6 @@
         <enforcer.skip>true</enforcer.skip>
         <access-modifier-checker.skip>true</access-modifier-checker.skip>
         <invoker.skip>true</invoker.skip>
-        <spotless.check.skip>true</spotless.check.skip>
         <checkstyle.skip>true</checkstyle.skip>
         <yarn.lint.skip>true</yarn.lint.skip>
       </properties>


### PR DESCRIPTION
I see no straightforward way to fix #425, so this PR simply redefines the expected behavior to be the new behavior rather than the old behavior by removing `spotless.check.skip` from any Maven profiles where it is defined, thus shifting the burden on the consumer to pass in `-Dspotless.check.skip` anywhere they were previously passing in `-Pquick-build`. While a minor burden, this seems good enough especially given the lack of any obvious alternatives.

Fixes #425.