### PR TITLE
Flatten `<repositories>` part of deployed pom when using JEP-229

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -856,6 +856,10 @@
                   <flattenMode>oss</flattenMode>
                   <outputDirectory>${project.build.directory}</outputDirectory>
                   <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
+                  <!-- TODO https://github.com/mojohaus/flatten-maven-plugin/issues/362 -->
+                  <pomElements>
+                    <repositories>flatten</repositories>
+                  </pomElements>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Counterpart of https://github.com/jenkinsci/plugin-pom/pull/802,
workarounds https://github.com/mojohaus/flatten-maven-plugin/issues/362

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Updated pom of `stapler` with SNAPSHOT of this project

Ran
```
mvn -Pquick-build -Dset.changelist -Dignore.dirt verify
```

Verified that `**/target/stapler-*-<version>.pom` no longer has a `<repositories>` section.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
