### PR TITLE
Add `-proc:full` to compiler arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -957,6 +957,25 @@
       </build>
     </profile>
     <profile>
+      <id>annotation-processors</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs>
+                <arg>-proc:full</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!--  a profile that disables as much testing as possible whilst still producing the artifacts -->
       <id>quick-build</id>
       <properties>


### PR DESCRIPTION
Fixes jenkinsci/plugin-pom#811