### PR TITLE
Revert "Bump com.github.spotbugs:spotbugs-maven-plugin from 4.7.3.6 to 4.8.1.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <mockito.version>5.7.0</mockito.version>
     <spotbugs-annotations.version>4.8.1</spotbugs-annotations.version>
-    <spotbugs-maven-plugin.version>4.8.1.0</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.7.3.6</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.40.0</spotless-maven-plugin.version>
     <stapler-maven-plugin.version>175.vff879c6738b_6</stapler-maven-plugin.version>
   </properties>


### PR DESCRIPTION
Reverts jenkinsci/pom#498 because this new version results in dozens of noisy SpotBugs violations of questionable value.