### PR TITLE
Ban Jenkins test harness in compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -689,6 +689,8 @@
                     <exclude>log4j:log4j</exclude>
                     <!-- CVE-2021-44228 -->
                     <exclude>org.apache.logging.log4j:*:(,2.15.0-rc1]</exclude>
+                    <!-- The Jenkins test harness wreaks havoc in production, so ensure it is in test scope. -->
+                    <exclude>org.jenkins-ci.main:jenkins-test-harness:*:jar:compile</exclude>
                     <!-- PowerMock has been abandoned and does not work on newer Java versions. -->
                     <exclude>org.powermock:powermock-api-easymock</exclude>
                     <exclude>org.powermock:powermock-api-mockito2</exclude>


### PR DESCRIPTION
Like https://github.com/jenkinsci/plugin-pom/pull/864, but for `jenkinsci/pom`.

### Testing done

See https://github.com/jenkinsci/plugin-pom/pull/864.