### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -628,10 +628,7 @@
             <indent>
               <spaces>true</spaces>
             </indent>
-            <palantirJavaFormat>
-              <!-- TODO https://github.com/diffplug/spotless/issues/1774 -->
-              <version>2.35.0</version>
-            </palantirJavaFormat>
+            <palantirJavaFormat />
             <removeUnusedImports />
             <trimTrailingWhitespace />
           </java>


### PR DESCRIPTION
https://github.com/diffplug/spotless/issues/1774 has been fixed in the latest release, and we have upgraded to that release.

### Testing done

Ran `mvn spotless:check` on Java 21 without the workaround in place.