### PR TITLE
[JENKINS-72956] Skip Spotless in quick-build profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1010,6 +1010,7 @@
         <!-- we can not use maven.test.skip because we may be producing a test jar -->
         <skipTests>true</skipTests>
         <spotbugs.skip>true</spotbugs.skip>
+        <spotless.skip>true</spotless.skip>
         <enforcer.skip>true</enforcer.skip>
         <access-modifier-checker.skip>true</access-modifier-checker.skip>
         <invoker.skip>true</invoker.skip>


### PR DESCRIPTION
This sets `spotless.skip`, a [fairly recent](https://github.com/diffplug/spotless/blob/1ad019da39f8994d5b7ccd86a536678cb38fbdea/plugin-maven/CHANGES.md?plain=1#L101-L103) property that [takes precedence](https://github.com/diffplug/spotless/blob/1ad019da39f8994d5b7ccd86a536678cb38fbdea/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java#L244-L259) over `spotless.check.skip`.

See [JENKINS-72956](https://issues.jenkins.io/browse/JENKINS-72956), and https://github.com/jenkinsci/jenkins/pull/9124 for recent backstory. Amends #427, addresses #425 as originally requested.

### Testing done

Just a quick local snapshot install, used in the core build with `-Pquick-build`.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
