### PR TITLE
Remove `maven-pmd-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-    <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
     <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>3.2.0</maven-remote-resources-plugin.version>
@@ -293,10 +292,6 @@
             <locale>en_US</locale>
             <notimestamp>true</notimestamp>
           </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-pmd-plugin</artifactId>
-          <version>${maven-pmd-plugin.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>


### PR DESCRIPTION
Consumers of this POM don't use `maven-pmd-plugin` anymore.

### Testing done

`rg maven-pmd-plugin` showed no consumers of this repository.