### PR TITLE
Revert "Bump org.apache.maven.plugins:maven-site-plugin from 3.12.1 to 3.20.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>3.2.0</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
+    <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>


### PR DESCRIPTION
Reverts jenkinsci/pom#590

After deploying this today, I started getting these errors from Jenkins Maven plugins:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.20.0:site (default-site) on project jellydoc-maven-plugin: Failed to create context for skin: Cannot use skin: has [1.11.1,2.0.0-M1) Doxia Sitetools prerequisite, but current is 2.0.0-M19 -> [Help 1]
```