### PR TITLE
Add 'may-spotless-apply' profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1014,5 +1014,28 @@
         <yarn.lint.skip>true</yarn.lint.skip>
       </properties>
     </profile>
+    <profile>
+      <id>may-spotless-apply</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotless-apply</id>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>validate</phase>
+                <configuration>
+                  <skip>${spotless.check.skip}</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
I often find myself forgetting to apply spotless before committing.

On some repositories, I have set up a pre-commit git hook running `mvn spotless:check`. However, this has to be set up on each repository that has spotless check enabled, and disabled on those which don't.

I think this goes one step further, by defining a conventional maven profile `may-spotless-apply` that will run `spotless:apply` *only* if spotless is enabled for the given repository.

This allows any user to incorporate `-Pmay-spotless-apply` as part of their usual build command (or defined in their maven settings active profiles section), and have `spotless:apply` automatically called if the project has it enabled.

<!-- Please describe your pull request here. -->
See also https://github.com/jenkinsci/plugin-pom/pull/1017

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
