### PR TITLE
Update Bridge Method Injector Group ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@
                 </pluginExecution>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId>com.infradna.tool</groupId>
+                    <groupId>io.jenkins.tools</groupId>
                     <artifactId>bridge-method-injector</artifactId>
                     <versionRange>[1.4,)</versionRange>
                     <goals>


### PR DESCRIPTION
With https://github.com/jenkinsci/bridge-method-injector/pull/124 comes a new Maven Group ID.