### PR TITLE
Revert "Update dependency de.skuzzle.enforcer:restrict-imports-enforcer-rule to v3.0.2-develop"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@
           <dependency>
             <groupId>de.skuzzle.enforcer</groupId>
             <artifactId>restrict-imports-enforcer-rule</artifactId>
-            <version>3.0.2-develop</version>
+            <version>3.0.1</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Reverts jenkinsci/pom#862 because the comment in the [release notes](https://github.com/skuzzle/restrict-imports-enforcer-rule/releases/tag/v3.0.2) says that it should not be used.